### PR TITLE
Update welcome filter and kicks handling

### DIFF
--- a/app/handlers/new_chat_members.py
+++ b/app/handlers/new_chat_members.py
@@ -51,10 +51,14 @@ async def new_chat_member(message: types.Message, chat: Chat):
     users = {}
     for new_member in message.new_chat_members:
         try:
-            await message.chat.restrict(
-                new_member.id, permissions=types.ChatPermissions(can_send_messages=False)
-            )
-            users[new_member.id] = new_member.get_mention()
+            chat_member = await message.chat.get_member(new_member.id)
+            if chat_member.status == "restricted":
+                return False  # ignore user that's been restricted to avoid capcha abusing.
+            else:
+                await message.chat.restrict(
+                    new_member.id, permissions=types.ChatPermissions(can_send_messages=False)
+                )
+                users[new_member.id] = new_member.get_mention()
         except BadRequest as e:
             logger.error(
                 "Cannot restrict chat member {user} in chat {chat} with error: {error}",

--- a/app/handlers/new_chat_members.py
+++ b/app/handlers/new_chat_members.py
@@ -119,7 +119,6 @@ async def cq_join_list(query: types.CallbackQuery, callback_data: dict):
     else:
         await query.answer(_("Bad answer."), show_alert=True)
         await asyncio.sleep(2)
-        await query.message.chat.kick(query.from_user.id)
         await query.message.chat.unban(query.from_user.id)
 
     users_list = await join_list.check_list(

--- a/app/handlers/simple_admin.py
+++ b/app/handlers/simple_admin.py
@@ -142,7 +142,6 @@ async def text_report_admins(message: types.Message):
 )
 async def cmd_leave(message: types.Message):
     try:
-        await message.chat.kick(user_id=message.from_user.id)
         await message.chat.unban(user_id=message.from_user.id)
         msg = await message.answer(
             _("User {user} leave this chat...").format(user=message.from_user.get_mention())


### PR DESCRIPTION
Firstly, when we want to kick an active user, we can just **unban** them instead of _kick and unban_. So it's more efficient that way.
Secondly, to fit the current bot functionality I've decided to fix **welcome filter abusing** by ignoring restricted users.
