### PR TITLE
Fix #6

### DIFF
--- a/app/handlers/superuser.py
+++ b/app/handlers/superuser.py
@@ -8,7 +8,7 @@ _ = i18n.gettext
 
 @dp.message_handler(commands=["set_superuser"], commands_prefix="!", is_superuser=True)
 async def cmd_superuser(message: types.Message):
-    args = message.get_args()
+    args = message.text.partition(" ")[2]
     if not args or not args[0].isdigit():
         return False
     args = args.split()


### PR DESCRIPTION
Aiogram Message get_args() method have no support for commands with custom prefixes, so !set_superuser command will never work this way. We'll replace it for now.
Fixes #6 